### PR TITLE
ec2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,7 +45,7 @@ jobs:
 
     strategy:
       matrix:
-        stack: [iam, budgets, certificates, bertie-blackman, bertie-blackman-ses]
+        stack: [iam, budgets, certificates, bertie-blackman, bertie-blackman-ses, ec2]
     env:
       AWS_REGION: eu-west-2
 

--- a/bin/main.ts
+++ b/bin/main.ts
@@ -1,7 +1,14 @@
 #!/usr/bin/env node
 import 'source-map-support/register'
 import * as cdk from '@aws-cdk/core'
-import { BudgetsStack, IAMStack, StaticSiteStack, CertificatesStack, SESStack } from '../lib'
+import {
+  BudgetsStack,
+  IAMStack,
+  StaticSiteStack,
+  CertificatesStack,
+  SESStack,
+  EC2Stack,
+} from '../lib'
 
 const regions = {
   primary: 'eu-west-2',
@@ -24,3 +31,5 @@ new SESStack(app, 'bertie-blackman-ses', {
   env: { region: regions.secondary },
   forwardingAddress: 'blackmanrgh@gmail.com',
 })
+
+new EC2Stack(app, 'ec2', { env: { region: regions.primary } })

--- a/lib/ec2.test.ts
+++ b/lib/ec2.test.ts
@@ -1,0 +1,20 @@
+import { expect as expectCDK, haveResourceLike } from '@aws-cdk/assert'
+import * as cdk from '@aws-cdk/core'
+import { EC2Stack } from './ec2'
+
+describe('EC2Stack', () => {
+  const app = new cdk.App()
+  const stack = new EC2Stack(app, 'ec2')
+
+  it('creates a VPC', () => {
+    expectCDK(stack).to(haveResourceLike('AWS::EC2::VPC'))
+  })
+
+  it('creates an instance', () => {
+    expectCDK(stack).to(haveResourceLike('AWS::EC2::Instance'))
+  })
+
+  it('creates an IAM role', () => {
+    expectCDK(stack).to(haveResourceLike('AWS::IAM::Role'))
+  })
+})

--- a/lib/ec2.ts
+++ b/lib/ec2.ts
@@ -1,7 +1,70 @@
-import { Stack, App, StackProps } from '@aws-cdk/core'
+import { Stack, App, StackProps, CfnOutput } from '@aws-cdk/core'
+import {
+  Vpc,
+  Instance,
+  InstanceType,
+  AmazonLinuxImage,
+  CloudFormationInit,
+  InitConfig,
+  InitPackage,
+  InitCommand,
+  SecurityGroup,
+  Peer,
+  Port,
+  SubnetType,
+} from '@aws-cdk/aws-ec2'
 
 export class EC2Stack extends Stack {
   constructor(scope: App, id: string, props?: StackProps) {
     super(scope, id, props)
+
+    const vpc = new Vpc(this, 'EC2VPC')
+
+    const instanceType = new InstanceType('t2.micro')
+
+    const machineImage = new AmazonLinuxImage()
+
+    const securityGroup = new SecurityGroup(this, 'EC2SecurityGroup', {
+      vpc,
+      description: 'Allow ssh access to ec2 instances',
+      allowAllOutbound: true,
+    })
+
+    securityGroup.addIngressRule(Peer.anyIpv4(), Port.tcp(22), 'allow ssh access from the world')
+
+    const instance = new Instance(this, 'EC2Instance', {
+      vpc,
+      instanceType,
+      machineImage,
+      keyName: 'main-beast',
+      securityGroup,
+      vpcSubnets: { subnetType: SubnetType.PUBLIC },
+      init: CloudFormationInit.fromConfigSets({
+        configSets: {
+          default: ['yumPreinstall', 'config'],
+        },
+        configs: {
+          yumPreinstall: new InitConfig([
+            InitPackage.yum('git'),
+            InitPackage.yum('zsh'),
+            InitPackage.yum('util-linux-user'),
+          ]),
+          config: new InitConfig([
+            InitCommand.shellCommand('yum update'),
+            InitCommand.shellCommand('sudo chsh -s $(which zsh)'),
+            // InitFile.fromString(
+            //   '~/.ssh/authorized_keys',
+            //   'ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDHeqYWB4dlN9LM3GpFRz7coqvmPp+oZzY6HmaODJHOX5h+PZWR2V/EdMKqT4crQXZ+iegc+un+NrnpuxJC0w9ZHzgNPTaYY7aavnoUiRB5m9cHYDqL9O+69rp8PNxrpT/fBZONmBiTUJCKqlb+OigDcdECGK6ebgNMLskJ1uSzhp1x1VM3a2koQTFJuJ1M5irUPB3zLaGbsQW8D60MkaXsHPToA/yh+CJdKkYTB+T4Y/JhiY/sIRBLg3ijaLEDzCf5jBfhJNB8amPC3OWDiJe/E9kmdx+18KQDu/d5aBbp6UL4fOVnjKS+HXMWqFs131LNEB2KdHccTZjWxgiwLFpC/DQ7tKswTULEYe1/ZRSOJi+yXMMIYrY5jsYmhhyG7HWRbZkqN5vdlLMB1rQrM+uugv9hNCa1d3lbRh1HqVxESRrcGtVJi1ZBSqSOUI66qfm6Nb1/F45NQDqNKHMK94d3RC0ErHSkCnhkBI5fs4E9enlYz3LoXvQa2ngJNCes7CxWCZ0/JEt9IH9zVPztuPRp+aVSZmDLBDG10wh/9KQ8IIjBID2/+rboTNe7KK/phNw/VSUh53avcnbe9UVDdQevwbbzjQloiiNYyJK1ehsrFcm4k/7iWMyZpAPB8/8SxbMu62g+HweNxSlsLKKRLJCbF8IwQ8vgPLk/zb8jXP2gxw== bertie.blackman@cinch.co.uk',
+            // ),
+          ]),
+        },
+      }),
+    })
+
+    new CfnOutput(this, 'ec2-public-ip', {
+      value: instance.instancePublicIp,
+      exportName: 'publicIP',
+      description: 'The public IP address of the EC2 instance',
+    })
   }
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -3,5 +3,6 @@ import { IAMStack } from './iam'
 import { StaticSiteStack } from './static-site'
 import { CertificatesStack } from './certificates'
 import { SESStack } from './ses'
+import { EC2Stack } from './ec2'
 
-export { BudgetsStack, IAMStack, StaticSiteStack, CertificatesStack, SESStack }
+export { BudgetsStack, IAMStack, StaticSiteStack, CertificatesStack, SESStack, EC2Stack }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "watch": "tsc -w",
     "test": "jest",
     "deploy": "cdk deploy --require-approval never",
+    "destroy": "cdk destroy",
     "synth": "cdk synth ",
     "prettier:check": "prettier --check \"**/*.*\"",
     "prettier:fix": "prettier --write \"**/*.*\"",


### PR DESCRIPTION
- Bump jest from 26.5.0 to 26.5.2 (#35)
- Bump aws-cdk from 1.66.0 to 1.67.0 (#36)
- Bump @types/node from 14.11.5 to 14.11.7 (#37)
- Bump @types/node from 14.11.7 to 14.11.8 (#38)
- Bump eslint from 7.10.0 to 7.11.0 (#39)
- Bump jest from 26.5.2 to 26.5.3 (#40)
- Bump @typescript-eslint/parser from 4.4.0 to 4.4.1 (#41)
- Bump aws-cdk from 1.67.0 to 1.68.0 (#43)
- Bump @typescript-eslint/eslint-plugin from 4.4.0 to 4.4.1 (#42)
- Bump lint-staged from 10.4.0 to 10.4.2 (#44)
- Bump aws-cdk from 1.68.0 to 1.69.0 (#47)
- Bump eslint-config-prettier from 6.12.0 to 6.13.0 (#46)
- Bump @types/node from 14.11.8 to 14.11.10 (#45)
- Bump @typescript-eslint/eslint-plugin from 4.4.1 to 4.5.0 (#49)
- Bump jest from 26.5.3 to 26.6.0 (#50)
- Bump @typescript-eslint/parser from 4.4.1 to 4.5.0 (#48)
- Bump @types/node from 14.11.10 to 14.14.0 (#51)
- Bump eslint-config-prettier from 6.13.0 to 6.14.0 (#53)
- Bump @types/jest from 26.0.14 to 26.0.15 (#52)
- Bump @types/node from 14.14.0 to 14.14.2 (#54)
- Bump @types/node from 14.14.2 to 14.14.3 (#55)
- Bump @types/node from 14.14.3 to 14.14.5 (#60)
- Bump eslint from 7.11.0 to 7.12.0 (#56)
- Bump ts-jest from 26.4.1 to 26.4.2 (#58)
- Bump jest from 26.6.0 to 26.6.1 (#59)
- Bump @typescript-eslint/eslint-plugin from 4.5.0 to 4.6.0 (#61)
- Bump @typescript-eslint/parser from 4.5.0 to 4.6.0 (#63)
- Bump ts-jest from 26.4.1 to 26.4.3 (#64)
- Bump eslint from 7.11.0 to 7.12.1 (#62)
- Bump lint-staged from 10.4.2 to 10.5.0 (#65)
- Bump typescript from 4.0.3 to 4.0.5 (#67)
- Bump eslint-config-prettier from 6.14.0 to 6.15.0 (#69)
- Bump @types/node from 14.14.5 to 14.14.6 (#70)
- Bump lint-staged from 10.5.0 to 10.5.1 (#71)
- Bump @typescript-eslint/eslint-plugin from 4.6.0 to 4.6.1 (#72)
- Bump jest from 26.6.1 to 26.6.3 (#75)
- Bump @typescript-eslint/parser from 4.6.0 to 4.6.1 (#73)
- Bump eslint from 7.12.1 to 7.13.0 (#76)
- Bump @typescript-eslint/parser from 4.6.1 to 4.7.0 (#78)
- Bump ts-jest from 26.4.3 to 26.4.4 (#77)
- Bump @types/node from 14.14.6 to 14.14.7 (#79)
- Bump @typescript-eslint/eslint-plugin from 4.6.1 to 4.7.0 (#80)
- Bump @typescript-eslint/eslint-plugin from 4.7.0 to 4.8.0 (#81)
- Bump @typescript-eslint/eslint-plugin from 4.8.0 to 4.8.1 (#83)
- Bump @types/node from 14.14.7 to 14.14.9 (#86)
- Bump @typescript-eslint/parser from 4.7.0 to 4.8.1 (#85)
- Bump prettier from 2.1.2 to 2.2.0 (#87)
- Updates deps
- Updates deploy pipeline
- License
- Bulldozer
- UPdates AWS CDK
- Adds push hook for tests
- Adds push hook for tests
- CDK CLI update
- Lock files
- Uses yarn
- Creates EC2 instance
